### PR TITLE
Alertrules fix

### DIFF
--- a/_examples/alert_rule.go
+++ b/_examples/alert_rule.go
@@ -38,11 +38,13 @@ func main() {
 
 	// Create an alert rule
 	rule, err := c.CreateAlertRule(uptycs.AlertRule{
-		Name:        "marcus test",
-		Description: "marcus test",
-		Grouping:    "MITRE",
-		GroupingL2:  "Impact",
-		GroupingL3:  "T1560",
+		Name:                "marcus test",
+		Description:         "marcus test",
+		Grouping:            "MITRE",
+		GroupingL2:          "Impact",
+		GroupingL3:          "T1560",
+		AlertNotifyCount:    1,
+		AlertNotifyInterval: 3600,
 		SQLConfig: &uptycs.SQLConfig{
 			IntervalSeconds: 3600,
 		},

--- a/uptycs/alertrule.go
+++ b/uptycs/alertrule.go
@@ -18,15 +18,11 @@ func (T AlertRule) KeysToDelete() []string {
 		"timeSuppresionDuration",
 		"seedId",
 		"throttled",
-		"alertTags",
 		"links",
 	}
 
 	if T.Type != "sql" {
 		keysToDelete = append(keysToDelete, "sqlConfig")
-	}
-	if T.Type != "javascript" {
-		keysToDelete = append(keysToDelete, "scriptConfig")
 	}
 
 	return keysToDelete

--- a/uptycs/alertrule.go
+++ b/uptycs/alertrule.go
@@ -12,11 +12,6 @@ func (T AlertRule) GetName() string {
 
 func (T AlertRule) KeysToDelete() []string {
 	keysToDelete := []string{
-		"name",
-		"description",
-		"code",
-		"type",
-		"rule",
 		"enabled",
 		"isInternal",
 		"timeSuppresionStart",

--- a/uptycs/models.go
+++ b/uptycs/models.go
@@ -7,15 +7,6 @@ type EventRules struct {
 	Limit  int         `json:"limit,omitempty"`
 }
 
-type ScriptConfig struct {
-	ID               string `json:"id,omitempty"`
-	QueryPackID      string `json:"querypackId,omitempty"`
-	TableName        string `json:"tableName,omitempty"`
-	EventCode        string `json:"eventCode,omitempty"`
-	EventMinSeverity string `json:"eventMinSeverity,omitempty"`
-	Added            bool   `json:"added"`
-}
-
 type EventRule struct {
 	ID            string          `json:"id,omitempty"`
 	Name          string          `json:"name,omitempty"`
@@ -37,7 +28,6 @@ type EventRule struct {
 	Score         string          `json:"score,omitempty"`
 	Lock          bool            `json:"lock"`
 	Exceptions    []RuleException `json:"exceptions"`
-	ScriptConfig  *ScriptConfig   `json:"scriptConfig,omitempty"`
 	SQLConfig     *SQLConfig      `json:"sqlConfig,omitempty"`
 	BuilderConfig BuilderConfig   `json:"builderConfig,omitempty"`
 	Links         []LinkItem      `json:"links,omitempty"`
@@ -93,7 +83,7 @@ type AlertRule struct {
 	Name                   string                 `json:"name,omitempty"`
 	Description            string                 `json:"description,omitempty"`
 	Code                   string                 `json:"code,omitempty"`
-	Type                   string                 `json:"type,omitempty"`
+	Type                   string                 `json:"type,omitempty" validate:"required,oneof=sql builder"`
 	Rule                   string                 `json:"rule,omitempty"`
 	Grouping               string                 `json:"grouping,omitempty"`
 	Enabled                bool                   `json:"enabled"`
@@ -115,7 +105,6 @@ type AlertRule struct {
 	AlertRuleExceptions    []RuleException        `json:"alertRuleExceptions"`
 	Destinations           []AlertRuleDestination `json:"destinations"`
 	SQLConfig              *SQLConfig             `json:"sqlConfig,omitempty"`
-	ScriptConfig           *ScriptConfig          `json:"scriptConfig,omitempty"`
 	Links                  []LinkItem             `json:"links,omitempty"`
 }
 


### PR DESCRIPTION
Fix alert rule notify attributes
Alert rules can use alert tags, names, etc on creation but only for sql. 
Javascript (and scriptconfig) not allowed per uptycs