### PR TITLE
Add support for lookup tables and query jobs (+results)

### DIFF
--- a/_examples/lookup_table.go
+++ b/_examples/lookup_table.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"github.com/uptycslabs/uptycs-client-go/uptycs"
+	"log"
+	"os"
+)
+
+func main() {
+	c, _ := uptycs.NewClient(uptycs.Config{
+		Host:       os.Getenv("UPTYCS_HOST"),
+		APIKey:     os.Getenv("UPTYCS_API_KEY"),
+		APISecret:  os.Getenv("UPTYCS_API_SECRET"),
+		CustomerID: os.Getenv("UPTYCS_CUSTOMER_ID"),
+	})
+
+	lookupTableByID, _ := c.GetLookupTable(uptycs.LookupTable{
+		ID: "7f042e5a-e4e8-47e7-8077-a0581411d4fd",
+	})
+	log.Println("Got LookupTable with ID ", lookupTableByID.ID)
+	_dataRow, _ := c.GetLookupTableDataRow(lookupTableByID, lookupTableByID.DataRows[0])
+	log.Println(fmt.Sprintf("%+v", _dataRow.Data))
+
+	// Create a lookupTable
+	newLookupTable, err := c.CreateLookupTable(uptycs.LookupTable{
+		Name:        "test",
+		Description: "a test",
+		IDField:     "id",
+	})
+	if err != nil {
+		panic(err)
+	}
+	log.Println(fmt.Sprintf("Created lookupTable '%s' with id '%s'", newLookupTable.Name, newLookupTable.ID))
+
+	// Add some data rows
+	_, err = c.CreateLookupTableDataRow(
+		newLookupTable,
+		uptycs.LookupTableDataRow{
+			Data: "[{\"id\": \"foo\", \"exception\":\"bar\"}]",
+		},
+	)
+	_, err = c.CreateLookupTableDataRow(
+		newLookupTable,
+		uptycs.LookupTableDataRow{
+			Data: "[{\"id\": \"asdf\", \"exception\":\"wut\"}]",
+		},
+	)
+
+	//Update Some data
+	_, err = c.UpdateLookupTableDataRow(
+		newLookupTable,
+		uptycs.LookupTableDataRow{
+			IDFieldValue: "foo",
+			Data:         "[{\"id\": \"foo\", \"exception\":\"new bar\"}]",
+		},
+	)
+
+	_updatedLookupTable, err := c.UpdateLookupTable(uptycs.LookupTable{
+		ID:   newLookupTable.ID,
+		Name: "test updated",
+	})
+	if err != nil {
+		panic(err)
+		log.Println(fmt.Sprintf("Error updating lookupTable '%s' with id '%s'", "", "54c7e31e-02a9-4b58-aaaf-e4a3b09e1980"))
+	}
+	log.Println(fmt.Sprintf("Updated lookupTable '%s' with id '%s'", _updatedLookupTable.Name, newLookupTable.ID))
+
+	//Delete Some data
+	_, err = c.DeleteLookupTableDataRow(
+		newLookupTable,
+		uptycs.LookupTableDataRow{
+			IDFieldValue: "foo",
+		},
+	)
+	_test, _ := c.GetLookupTable(uptycs.LookupTable{
+		ID: newLookupTable.ID,
+	})
+	log.Println(fmt.Sprintf("%+v", _test.DataRows[0].Data))
+
+	// Delete a lookupTable by ID
+	_, err = c.DeleteLookupTable(uptycs.LookupTable{
+		ID: newLookupTable.ID,
+	})
+	if err != nil {
+		panic(err)
+	}
+	log.Println(fmt.Sprintf("Deleted lookupTable '%s' with id '%s'", newLookupTable.Name, newLookupTable.ID))
+
+}

--- a/_examples/queryJob.go
+++ b/_examples/queryJob.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/uptycslabs/uptycs-client-go/uptycs"
+	"log"
+	"os"
+	"time"
+)
+
+func main() {
+	c, _ := uptycs.NewClient(uptycs.Config{
+		Host:       os.Getenv("UPTYCS_HOST"),
+		APIKey:     os.Getenv("UPTYCS_API_KEY"),
+		APISecret:  os.Getenv("UPTYCS_API_SECRET"),
+		CustomerID: os.Getenv("UPTYCS_CUSTOMER_ID"),
+	})
+
+	newQueryJob, err := c.CreateQueryJob(uptycs.QueryJob{
+		Name:  "test",
+		Query: heredoc.Doc(`SELECT instance_id,tags from aws_ec2_instance_current limit 1;`),
+		Type:  "global",
+	})
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println(fmt.Sprintf("Created Query Job  with id '%s'", newQueryJob.ID))
+	time.Sleep(10 * time.Second)
+
+	_foo, err := c.GetQueryJobResults(uptycs.QueryJobResult{
+		ID: newQueryJob.ID,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println(fmt.Sprintf("%+v", _foo.Items[0].RowData))
+
+}

--- a/uptycs/fixtures/lookup_table.json
+++ b/uptycs/fixtures/lookup_table.json
@@ -1,0 +1,28 @@
+{
+  "id": "7f042e5a-e4e8-47e7-8077-a0581411d4fd",
+  "customerId": "111111111111-111111-11111-111111-111111111",
+  "name": "aws_account_metadata",
+  "description": "Used to lookup business context on AWS accounts.",
+  "active": true,
+  "idField": "id",
+  "rowCount": 3,
+  "forRuleEngine": true,
+  "createdBy": "66a9a52c-5fa0-4cf4-abe7-da5504f67950",
+  "updatedBy": "66a9a52c-5fa0-4cf4-abe7-da5504f67950",
+  "createdAt": "2022-06-22T03:58:40.114Z",
+  "updatedAt": "2022-06-22T03:58:40.349Z",
+  "dataLookupTable": null,
+  "links": [
+    {
+      "rel": "self",
+      "title": "Lookup Table information",
+      "href": "/api/customers/111111111111-111111-11111-111111-111111111/lookupTables/7f042e5a-e4e8-47e7-8077-a0581411d4fd"
+    },
+    {
+      "rel": "parent",
+      "title": "Lookup Tables information",
+      "href": "/api/customers/111111111111-111111-11111-111111-111111111/lookupTables"
+    }
+  ],
+  "fetchRowsquery": "SELECT id_field_value,data FROM upt_lookup_rows WHERE lookup_table_id = '7f042e5a-e4e8-47e7-8077-a0581411d4fd'"
+}

--- a/uptycs/fixtures/query_job.json
+++ b/uptycs/fixtures/query_job.json
@@ -1,0 +1,59 @@
+{
+  "links": [
+    {
+      "rel": "self",
+      "title": "Query job information",
+      "href": "/api/customers/11111111-1111-1111-1111-111111111111/queryJobs/b6885999-3bb0-4d8e-84b3-46883f4d7506"
+    },
+    {
+      "rel": "parent",
+      "title": "Query jobs information",
+      "href": "/api/customers/11111111-1111-1111-1111-111111111111/queryJobs"
+    }
+  ],
+  "id": "b6885999-3bb0-4d8e-84b3-46883f4d7506",
+  "customerId": "11111111-1111-1111-1111-111111111111",
+  "type": "global",
+  "name": "b86c2befb58987cb5d4f14210784c9df",
+  "query": "test",
+  "parameters": [
+    {
+      "key": "from",
+      "dataType": "DATE",
+      "multiple": false,
+      "optional": false,
+      "defaultValue": "2023-05-22T17:22:36.323Z"
+    },
+    {
+      "key": "to",
+      "dataType": "DATE",
+      "multiple": false,
+      "optional": false,
+      "defaultValue": "2023-05-22T19:27:08.322Z"
+    }
+  ],
+  "parameterValues": {
+    "to": "2023-05-22T19:27:08.322Z",
+    "from": "2023-05-22T17:22:36.323Z"
+  },
+  "filters": null,
+  "queryId": "4934a4b8-0625-452f-b5ec-0d6be1da2d85",
+  "status": "QUEUED",
+  "rowCount": 0,
+  "startTime": null,
+  "endTime": null,
+  "error": null,
+  "purged": false,
+  "incompleteResults": false,
+  "alertId": null,
+  "createdBy": "f48f4c40-9c4a-47bb-9e3f-797d4deca92a",
+  "updatedBy": null,
+  "createdAt": "2023-05-22T19:27:08.334Z",
+  "updatedAt": "2023-05-22T19:27:08.334Z",
+  "source": "SCHEDULED",
+  "resultStore": null,
+  "agentType": "asset",
+  "resourceType": "asset",
+  "queryStats": null,
+  "sessionProperties": null
+}

--- a/uptycs/fixtures/query_job_result.json
+++ b/uptycs/fixtures/query_job_result.json
@@ -1,0 +1,75 @@
+{
+  "items": [
+    {
+      "createdAt": "2023-06-13",
+      "rowDataHash": "248f094d-c546-34dc-8ca2-06c869c4bbed",
+      "customerId": "11111111-1111-1111-1111-111111111111",
+      "rowData": {
+        "instance_id": "i-027e4ca22fe5a1518",
+        "tags": "{\"Foo\":\"some foo\"}",
+        "foo": 1
+      },
+      "rowNumber": 1,
+      "queryJobId": "7bc5024f-003b-4934-97d6-478bc603a684"
+    },
+    {
+      "createdAt": "2023-06-13",
+      "rowDataHash": "8917663c-4f37-3d28-b771-acfd00f2e816",
+      "customerId": "11111111-1111-1111-1111-111111111111",
+      "rowData": {
+        "instance_id": "i-08c0f696e648e37cd",
+        "tags": "{\"Foo\":\"some other foo\"}",
+        "foo": 2
+      },
+      "rowNumber": 2,
+      "queryJobId": "7bc5024f-003b-4934-97d6-478bc603a684"
+    }
+  ],
+  "links": [
+    {
+      "rel": "self",
+      "title": "Query job results information",
+      "href": "/api/customers/11111111-1111-1111-1111-111111111111/queryJobs/7bc5024f-003b-4934-97d6-478bc603a684/results"
+    },
+    {
+      "rel": "parent",
+      "title": "Query job information",
+      "href": "/api/customers/11111111-1111-1111-1111-111111111111/queryJobs/7bc5024f-003b-4934-97d6-478bc603a684"
+    }
+  ],
+  "queryStats": {
+    "cpuTimeMillis": 106,
+    "processedRows": 5963,
+    "processedBytes": 0,
+    "elapsedTimeMillis": 386
+  },
+  "status": "FINISHED",
+  "id": "7bc5024f-003b-4934-97d6-478bc603a684",
+  "error": null,
+  "endTime": "2023-06-13T15:27:01.209Z",
+  "startTime": "2023-06-13T15:27:00.692Z",
+  "rowCount": 2,
+  "resultStore": "cache",
+  "columns": [
+    {
+      "name": "instance_id",
+      "type": "TEXT",
+      "originalName": "instance_id",
+      "link": ""
+    },
+    {
+      "name": "tags",
+      "type": "TEXT",
+      "originalName": "tags",
+      "link": ""
+    },
+    {
+      "name": "foo",
+      "type": "NUMBER_INTEGER",
+      "originalName": "foo",
+      "link": ""
+    }
+  ],
+  "offset": 0,
+  "limit": 50000
+}

--- a/uptycs/lookup_table.go
+++ b/uptycs/lookup_table.go
@@ -1,0 +1,68 @@
+package uptycs
+
+import (
+	"errors"
+	"fmt"
+)
+
+func (T LookupTable) GetID() string {
+	return T.ID
+}
+
+func (T LookupTable) GetName() string {
+	return T.Name
+}
+
+func (T LookupTable) KeysToDelete() []string {
+	return []string{
+		"enabled",
+		"active",
+		"dataLookupTable",
+		"fetchRowsquery",
+		"forRuleEngine",
+		"rowCount",
+	}
+}
+
+func (c *Client) CreateLookupTable(lookupTable LookupTable) (LookupTable, error) {
+	return doCreate(c, lookupTable, "lookupTables", []string{})
+}
+
+func (c *Client) UpdateLookupTable(lookupTable LookupTable) (LookupTable, error) {
+	_, err := doUpdate(c, lookupTable, "lookupTables", []string{})
+	if err != nil {
+		return LookupTable{}, err
+	}
+
+	_lookupTable, err := doGet(c, lookupTable, "lookupTables")
+	_lookupTableDataRows, _ := GetAllLookupTableData(c, fmt.Sprintf("lookupTables/%s/data", lookupTable.ID))
+	_lookupTable.DataRows = append(_lookupTable.DataRows, _lookupTableDataRows...)
+	return _lookupTable, err
+}
+
+func (c *Client) GetLookupTables() (LookupTables, error) {
+	return doGetMany(c, LookupTables{}, "lookupTables")
+}
+
+func (c *Client) GetLookupTable(lookupTable LookupTable) (LookupTable, error) {
+	if len(lookupTable.ID) == 0 {
+		all, _ := c.GetLookupTables()
+		for _, _item := range all.Items {
+			if _item.Name == lookupTable.Name {
+				_lookupTableDataRows, _ := GetAllLookupTableData(c, fmt.Sprintf("lookupTables/%s/data", lookupTable.ID))
+				_item.DataRows = append(_item.DataRows, _lookupTableDataRows...)
+				return _item, nil
+			}
+		}
+	} else {
+		_lookupTable, err := doGet(c, lookupTable, "lookupTables")
+		_lookupTableDataRows, _ := GetAllLookupTableData(c, fmt.Sprintf("lookupTables/%s/data", lookupTable.ID))
+		_lookupTable.DataRows = append(_lookupTable.DataRows, _lookupTableDataRows...)
+		return _lookupTable, err
+	}
+	return lookupTable, errors.New("lookupTable was not found")
+}
+
+func (c *Client) DeleteLookupTable(lookupTable LookupTable) (LookupTable, error) {
+	return doDelete(c, lookupTable, "lookupTables")
+}

--- a/uptycs/lookup_table_data_row.go
+++ b/uptycs/lookup_table_data_row.go
@@ -1,0 +1,83 @@
+package uptycs
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func (T LookupTableDataRow) GetID() string {
+	return T.ID
+}
+
+func (T LookupTableDataRow) GetName() string {
+	return T.Name
+}
+
+func (T LookupTableDataRow) KeysToDelete() []string {
+	return []string{}
+}
+
+func GetAllLookupTableData(c *Client, endpointStr string) ([]LookupTableDataRow, error) {
+	urlStr := fmt.Sprintf("%s/%s", c.HostURL, endpointStr)
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return []LookupTableDataRow{}, err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return []LookupTableDataRow{}, err
+	}
+
+	foundItems := make([]LookupTableDataRow, 1)
+
+	err = json.Unmarshal(body, &foundItems)
+	if err != nil {
+		return []LookupTableDataRow{}, err
+	}
+
+	return foundItems, nil
+}
+
+func (c *Client) FindLookupTableDataRow(lookupTable LookupTable, lookupTableDataRow LookupTableDataRow) (LookupTableDataRow, error) {
+	tableDataRows, err := GetAllLookupTableData(c, fmt.Sprintf("lookupTables/%s/data", lookupTable.ID))
+	for _, row := range tableDataRows {
+		if row.IDFieldValue == lookupTableDataRow.IDFieldValue {
+			return row, err
+		}
+	}
+	return LookupTableDataRow{}, err
+}
+
+func (c *Client) CreateLookupTableDataRow(lookupTable LookupTable, lookupTableDataRow LookupTableDataRow) (LookupTableDataRow, error) {
+	return lookupTableDataRow, doCreateRaw(c, string(lookupTableDataRow.Data), fmt.Sprintf("lookupTables/%s/data", lookupTable.ID))
+}
+
+func (c *Client) UpdateLookupTableDataRow(lookupTable LookupTable, lookupTableDataRow LookupTableDataRow) (LookupTableDataRow, error) {
+	_lookupTableDataRow, err := c.FindLookupTableDataRow(lookupTable, lookupTableDataRow)
+	if err != nil {
+		return LookupTableDataRow{}, err
+	}
+	_, err = doDelete(c, lookupTableDataRow, fmt.Sprintf("lookupTables/%s/data/%s", lookupTable.ID, _lookupTableDataRow.ID))
+	if err != nil {
+		return LookupTableDataRow{}, err
+	}
+
+	_ = doCreateRaw(c, string(lookupTableDataRow.Data), fmt.Sprintf("lookupTables/%s/data", lookupTable.ID))
+	_newLookupTableDataRow, err := c.FindLookupTableDataRow(lookupTable, lookupTableDataRow)
+	return _newLookupTableDataRow, err
+}
+
+func (c *Client) GetLookupTableDataRow(lookupTable LookupTable, lookupTableDataRow LookupTableDataRow) (LookupTableDataRow, error) {
+	return doGet(c, lookupTableDataRow, fmt.Sprintf("lookupTables/%s/data", lookupTable.ID))
+}
+
+func (c *Client) DeleteLookupTableDataRow(lookupTable LookupTable, lookupTableDataRow LookupTableDataRow) (LookupTableDataRow, error) {
+	_lookupTableDataRow, err := c.FindLookupTableDataRow(lookupTable, lookupTableDataRow)
+	if err != nil {
+		return LookupTableDataRow{}, err
+	}
+	_, err = doDelete(c, lookupTableDataRow, fmt.Sprintf("lookupTables/%s/data/%s", lookupTable.ID, _lookupTableDataRow.ID))
+	return LookupTableDataRow{}, err
+}

--- a/uptycs/lookup_table_test.go
+++ b/uptycs/lookup_table_test.go
@@ -1,0 +1,266 @@
+package uptycs
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLookupTable(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name    string
+		fixture string
+		id      string
+		out     interface{}
+	}
+
+	theTests := []convTest{
+		{
+			name:    "TestLookupTable",
+			fixture: "fixtures/lookup_table.json",
+			id:      "7f042e5a-e4e8-47e7-8077-a0581411d4fd",
+			out: LookupTable{
+				ID:              "7f042e5a-e4e8-47e7-8077-a0581411d4fd",
+				Name:            "aws_account_metadata",
+				Description:     "Used to lookup business context on AWS accounts.",
+				Active:          true,
+				IDField:         "id",
+				RowCount:        3,
+				ForRuleEngine:   true,
+				CreatedBy:       "66a9a52c-5fa0-4cf4-abe7-da5504f67950",
+				UpdatedBy:       "66a9a52c-5fa0-4cf4-abe7-da5504f67950",
+				CreatedAt:       "2022-06-22T03:58:40.114Z",
+				UpdatedAt:       "2022-06-22T03:58:40.349Z",
+				DataLookupTable: DataLookupTable{},
+				FetchRowsquery:  "SELECT id_field_value,data FROM upt_lookup_rows WHERE lookup_table_id = '7f042e5a-e4e8-47e7-8077-a0581411d4fd'",
+				Links: []LinkItem{
+					LinkItem{Rel: "self", Title: "Lookup Table information", Href: "/api/customers/111111111111-111111-11111-111111-111111111/lookupTables/7f042e5a-e4e8-47e7-8077-a0581411d4fd"},
+					LinkItem{Rel: "parent", Title: "Lookup Tables information", Href: "/api/customers/111111111111-111111-11111-111111-111111111/lookupTables"},
+				},
+			},
+		},
+	}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("GET", fmt.Sprintf("https://uptycs.foo/public/api/customers/d/lookupTables/%v", theT.id),
+				func(req *http.Request) (*http.Response, error) {
+					fixture, err := RespFromFixture(theT.fixture)
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return fixture, err
+				},
+			)
+
+			lookupTableResp, err := c.GetLookupTable(LookupTable{
+				ID: theT.id,
+			})
+
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			if !reflect.DeepEqual(lookupTableResp, theT.out) {
+				t.Log("Output does not match expected")
+				t.Logf("Expected: %v", theT.out)
+				t.Logf("Actual:   %v", lookupTableResp)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestDeleteLookupTable(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name string
+		in   LookupTable
+	}
+
+	theTests := []convTest{
+		{
+			name: "TestLookupTable",
+			in: LookupTable{
+				ID: "7f042e5a-e4e8-47e7-8077-a0581411d4fd",
+			},
+		},
+	}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://uptycs.foo/public/api/customers/d/lookupTables/%v", theT.in.ID),
+				func(req *http.Request) (*http.Response, error) {
+					resp, err := httpmock.NewJsonResponse(200, "{}")
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return resp, err
+				},
+			)
+
+			_, err := c.DeleteLookupTable(theT.in)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			countInfo := httpmock.GetCallCountInfo()
+
+			assert.Equal(t, countInfo[fmt.Sprintf("DELETE https://uptycs.foo/public/api/customers/d/lookupTables/%v", theT.in.ID)], 1)
+			// TODO: assert the body that was intercepted by the mock
+		})
+	}
+}
+
+func TestPutLookupTable(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name    string
+		fixture string
+		in      LookupTable
+	}
+
+	theTests := []convTest{
+		{
+			name:    "TestLookupTable",
+			fixture: "fixtures/lookup_table.json",
+			in: LookupTable{
+				ID:          "7f042e5a-e4e8-47e7-8077-a0581411d4fd",
+				Name:        "aws_account_metadata",
+				Description: "Used to lookup business context on AWS accounts.",
+				IDField:     "id",
+			},
+		},
+	}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("GET", fmt.Sprintf("https://uptycs.foo/public/api/customers/d/lookupTables/%v", theT.in.ID),
+				func(req *http.Request) (*http.Response, error) {
+					fixture, err := RespFromFixture(theT.fixture)
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return fixture, err
+				},
+			)
+			httpmock.RegisterResponder("PUT", fmt.Sprintf("https://uptycs.foo/public/api/customers/d/lookupTables/%v", theT.in.ID),
+				func(req *http.Request) (*http.Response, error) {
+					fixture, err := RespFromFixture(theT.fixture)
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return fixture, err
+				},
+			)
+
+			_, err := c.UpdateLookupTable(theT.in)
+			assert.NoError(t, err)
+
+			countInfo := httpmock.GetCallCountInfo()
+
+			assert.Equal(t, countInfo[fmt.Sprintf("PUT https://uptycs.foo/public/api/customers/d/lookupTables/%v", theT.in.ID)], 1)
+			// TODO: assert the body that was intercepted by the mock
+		})
+	}
+}
+
+func TestCreateLookupTable(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name    string
+		fixture string
+		in      LookupTable
+	}
+
+	theTests := []convTest{
+		{
+			name:    "TestLookupTable",
+			fixture: "fixtures/lookup_table.json",
+			in: LookupTable{
+				Name:            "aws_account_metadata",
+				Description:     "Used to lookup business context on AWS accounts.",
+				Active:          true,
+				IDField:         "id",
+				RowCount:        3,
+				ForRuleEngine:   true,
+				CreatedBy:       "66a9a52c-5fa0-4cf4-abe7-da5504f67950",
+				UpdatedBy:       "66a9a52c-5fa0-4cf4-abe7-da5504f67950",
+				CreatedAt:       "2022-06-22T03:58:40.114Z",
+				UpdatedAt:       "2022-06-22T03:58:40.349Z",
+				DataLookupTable: DataLookupTable{},
+				FetchRowsquery:  "SELECT id_field_value,data FROM upt_lookup_rows WHERE lookup_table_id = '7f042e5a-e4e8-47e7-8077-a0581411d4fd'",
+				Links: []LinkItem{
+					LinkItem{Rel: "self", Title: "Lookup Table information", Href: "/api/customers/111111111111-111111-11111-111111-111111111/lookupTables/7f042e5a-e4e8-47e7-8077-a0581411d4fd"},
+					LinkItem{Rel: "parent", Title: "Lookup Tables information", Href: "/api/customers/111111111111-111111-11111-111111-111111111/lookupTables"},
+				},
+			},
+		},
+	}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("POST", "https://uptycs.foo/public/api/customers/d/lookupTables",
+				func(req *http.Request) (*http.Response, error) {
+					fixture, err := RespFromFixture(theT.fixture)
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return fixture, err
+				},
+			)
+
+			_, err := c.CreateLookupTable(theT.in)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			countInfo := httpmock.GetCallCountInfo()
+
+			assert.Equal(t, countInfo["POST https://uptycs.foo/public/api/customers/d/lookupTables"], 1)
+		})
+	}
+}

--- a/uptycs/models.go
+++ b/uptycs/models.go
@@ -1,5 +1,163 @@
 package uptycs
 
+type QueryJobColumn struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	OriginalName string `json:"originalName"`
+	Link         string `json:"link"`
+}
+
+type QueryJobParameter struct {
+	Key          string `json:"key"`
+	DataType     string `json:"dataType"`
+	Multiple     bool   `json:"multiple"`
+	Optional     bool   `json:"optional"`
+	DefaultValue string `json:"defaultValue"`
+}
+
+type QueryJobs struct {
+	Links  []LinkItem `json:"links"`
+	Items  []QueryJob `json:"items"`
+	Offset int        `json:"offset,omitempty"`
+	Limit  int        `json:"limit,omitempty"`
+}
+
+type QueryJob struct {
+	ID              string              `json:"id"`
+	Name            string              `json:"name"`
+	Query           string              `json:"query" validate:"required"`
+	Type            string              `json:"type" validate:"required,oneof=global"`
+	Parameters      []QueryJobParameter `json:"parameters"`
+	ParameterValues struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	} `json:"parameterValues"`
+	QueryID           string           `json:"queryId"`
+	Status            string           `json:"status"`
+	RowCount          int              `json:"rowCount"`
+	Columns           []QueryJobColumn `json:"columns"`
+	StartTime         string           `json:"startTime"`
+	EndTime           string           `json:"endTime"`
+	Error             QueryError       `json:"error"`
+	Purged            bool             `json:"purged"`
+	IncompleteResults bool             `json:"incompleteResults"`
+	AlertID           string           `json:"alertId"`
+	CreatedBy         string           `json:"createdBy"`
+	UpdatedBy         string           `json:"updatedBy"`
+	CreatedAt         string           `json:"createdAt"`
+	UpdatedAt         string           `json:"updatedAt"`
+	Source            string           `json:"source"`
+	ResultStore       string           `json:"resultStore"`
+	AgentType         string           `json:"agentType"`
+	ResourceType      string           `json:"resourceType"`
+	Links             []LinkItem       `json:"links"`
+	//SessionProperties interface{} `json:"sessionProperties"` # TODO: cant find any examples of this
+	//Filters  interface{} `json:"filters"` # TODO: cant find any examples of this
+	//QueryStats        interface{} `json:"queryStats"` # TODO: cant find any examples of this
+}
+
+type QueryError struct {
+	Message struct {
+		Detail string `json:"detail"`
+	} `json:"message"`
+}
+
+type QueryJobResult struct {
+	CreatedAt   string `json:"createdAt"`
+	RowDataHash string `json:"rowDataHash"`
+	CustomerID  string `json:"customerId"`
+	RowData     string `json:"rowData"`
+	RowNumber   int    `json:"rowNumber"`
+	QueryJobID  string `json:"queryJobId"`
+}
+
+type QueryJobResultColumn struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	OriginalName string `json:"originalName"`
+	Link         string `json:"link"`
+}
+
+type QueryJobResultsStats struct {
+	CPUTimeMillis     int `json:"cpuTimeMillis"`
+	ProcessedRows     int `json:"processedRows"`
+	ProcessedBytes    int `json:"processedBytes"`
+	ElapsedTimeMillis int `json:"elapsedTimeMillis"`
+}
+
+type QueryJobResults struct {
+	Links       []LinkItem             `json:"links"`
+	Items       []QueryJobResult       `json:"items"`
+	QueryStats  QueryJobResultsStats   `json:"queryStats"`
+	Status      string                 `json:"status"`
+	ID          string                 `json:"id"`
+	Error       QueryError             `json:"error"`
+	EndTime     string                 `json:"endTime"`
+	StartTime   string                 `json:"startTime"`
+	RowCount    int                    `json:"rowCount"`
+	ResultStore string                 `json:"resultStore"`
+	Columns     []QueryJobResultColumn `json:"columns"`
+	Offset      int                    `json:"offset,omitempty"`
+	Limit       int                    `json:"limit,omitempty"`
+}
+
+type LookupTables struct {
+	Links  []LinkItem    `json:"links"`
+	Items  []LookupTable `json:"items"`
+	Offset int           `json:"offset,omitempty"`
+	Limit  int           `json:"limit,omitempty"`
+}
+
+type DataLookupTable struct {
+	ID                      string `json:"id"`
+	LookupTableID           string `json:"lookupTableId"`
+	LookupTableName         string `json:"lookupTableName"`
+	LookupKeyName           string `json:"lookupKeyName"`
+	Enabled                 bool   `json:"enabled"`
+	RefreshFrequencyMinutes int    `json:"refreshFrequencyMinutes"`
+	LastRefreshAt           string `json:"lastRefreshAt"`
+	RefreshInfo             struct {
+		Key               string `json:"key"`
+		Query             string `json:"query"`
+		UptDay            int    `json:"uptDay"`
+		UptBatch          int    `json:"uptBatch"`
+		TableName         string `json:"tableName"`
+		CustomerDb        string `json:"customerDb"`
+		LookupTable       string `json:"lookupTable"`
+		LookupSchema      string `json:"lookupSchema"`
+		LastRefreshAt     int64  `json:"lastRefreshAt"`
+		RefreshFrequency  int    `json:"refreshFrequency"`
+		QueryForDashboard string `json:"queryForDashboard"`
+	} `json:"refreshInfo"`
+}
+
+type LookupTable struct {
+	ID              string               `json:"id"`
+	Name            string               `json:"name"`
+	Description     string               `json:"description,omitempty"`
+	Active          bool                 `json:"active"`
+	IDField         string               `json:"idField,omitempty"`
+	RowCount        int                  `json:"rowCount"`
+	ForRuleEngine   bool                 `json:"forRuleEngine"`
+	CreatedBy       string               `json:"createdBy"`
+	UpdatedBy       string               `json:"updatedBy"`
+	CreatedAt       string               `json:"createdAt"`
+	UpdatedAt       string               `json:"updatedAt"`
+	DataLookupTable DataLookupTable      `json:"dataLookupTable,omitempty"`
+	FetchRowsquery  string               `json:"fetchRowsquery"`
+	DataRows        []LookupTableDataRow `json:"-,omitempty"`
+	Links           []LinkItem           `json:"links"`
+}
+
+type LookupTableDataRow struct {
+	ID            string           `json:"id"`
+	Name          string           `json:"-"` //Not provided
+	LookupTableID string           `json:"lookupTableId"`
+	IDFieldValue  string           `json:"idFieldValue"`
+	Data          CustomJSONString `json:"data"`
+	CreatedAt     string           `json:"createdAt"`
+}
+
 type EventRules struct {
 	Links  []LinkItem  `json:"links"`
 	Items  []EventRule `json:"items"`
@@ -1102,12 +1260,12 @@ type AssetTag struct {
 }
 
 type iAPIType interface {
-	AlertRule | Destination | EventExcludeProfile | EventRule | User | Role | ObjectGroup | TagConfiguration | TagRule | Tag | FilePathGroup | YaraGroupRule | RegistryPath | Querypack | AuditConfiguration | ComplianceProfile | AlertRuleCategory | AssetGroupRule | AtcQuery | Carve | CustomProfile | FlagProfile | BlockRule | WindowsDefenderPreference | Exception | AssetTag | Asset
+	AlertRule | Destination | EventExcludeProfile | EventRule | User | Role | ObjectGroup | TagConfiguration | TagRule | Tag | FilePathGroup | YaraGroupRule | RegistryPath | Querypack | AuditConfiguration | ComplianceProfile | AlertRuleCategory | AssetGroupRule | AtcQuery | Carve | CustomProfile | FlagProfile | BlockRule | WindowsDefenderPreference | Exception | AssetTag | Asset | LookupTable | LookupTableDataRow | QueryJob | QueryJobResult
 	GetID() string
 	GetName() string
 	KeysToDelete() []string
 }
 
 type iAPITypes interface {
-	AlertRules | Destinations | EventExcludeProfiles | EventRules | Users | Roles | ObjectGroups | TagConfigurations | TagRules | Tags | FilePathGroups | YaraGroupRules | RegistryPaths | Querypacks | AuditConfigurations | ComplianceProfiles | AlertRuleCategories | AssetGroupRules | AtcQueries | Carves | CustomProfiles | FlagProfiles | BlockRules | WindowsDefenderPreferences | Exceptions | AssetTags | Assets
+	AlertRules | Destinations | EventExcludeProfiles | EventRules | Users | Roles | ObjectGroups | TagConfigurations | TagRules | Tags | FilePathGroups | YaraGroupRules | RegistryPaths | Querypacks | AuditConfigurations | ComplianceProfiles | AlertRuleCategories | AssetGroupRules | AtcQueries | Carves | CustomProfiles | FlagProfiles | BlockRules | WindowsDefenderPreferences | Exceptions | AssetTags | Assets | LookupTables | QueryJobResults | QueryJobs
 }

--- a/uptycs/models.go
+++ b/uptycs/models.go
@@ -27,29 +27,29 @@ type QueryJob struct {
 	Name            string              `json:"name"`
 	Query           string              `json:"query" validate:"required"`
 	Type            string              `json:"type" validate:"required,oneof=global"`
-	Parameters      []QueryJobParameter `json:"parameters"`
+	Parameters      []QueryJobParameter `json:"parameters,omitempty"`
 	ParameterValues struct {
-		From string `json:"from"`
-		To   string `json:"to"`
-	} `json:"parameterValues"`
-	QueryID           string           `json:"queryId"`
-	Status            string           `json:"status"`
+		From string `json:"from,omitempty"`
+		To   string `json:"to,omitempty"`
+	} `json:"parameterValues,omitempty"`
+	QueryID           string           `json:"queryId,omitempty"`
+	Status            string           `json:"status,omitempty"`
 	RowCount          int              `json:"rowCount"`
-	Columns           []QueryJobColumn `json:"columns"`
-	StartTime         string           `json:"startTime"`
-	EndTime           string           `json:"endTime"`
+	Columns           []QueryJobColumn `json:"columns,omitempty"`
+	StartTime         string           `json:"startTime,omitempty"`
+	EndTime           string           `json:"endTime,omitempty"`
 	Error             QueryError       `json:"error"`
 	Purged            bool             `json:"purged"`
 	IncompleteResults bool             `json:"incompleteResults"`
-	AlertID           string           `json:"alertId"`
+	AlertID           string           `json:"alertId,omitempty"`
 	CreatedBy         string           `json:"createdBy"`
 	UpdatedBy         string           `json:"updatedBy"`
 	CreatedAt         string           `json:"createdAt"`
 	UpdatedAt         string           `json:"updatedAt"`
-	Source            string           `json:"source"`
-	ResultStore       string           `json:"resultStore"`
-	AgentType         string           `json:"agentType"`
-	ResourceType      string           `json:"resourceType"`
+	Source            string           `json:"source,omitempty"`
+	ResultStore       string           `json:"resultStore,omitempty"`
+	AgentType         string           `json:"agentType,omitempty"`
+	ResourceType      string           `json:"resourceType,omitempty"`
 	Links             []LinkItem       `json:"links"`
 	//SessionProperties interface{} `json:"sessionProperties"` # TODO: cant find any examples of this
 	//Filters  interface{} `json:"filters"` # TODO: cant find any examples of this
@@ -63,19 +63,30 @@ type QueryError struct {
 }
 
 type QueryJobResult struct {
-	CreatedAt   string `json:"createdAt"`
-	RowDataHash string `json:"rowDataHash"`
-	CustomerID  string `json:"customerId"`
-	RowData     string `json:"rowData"`
-	RowNumber   int    `json:"rowNumber"`
-	QueryJobID  string `json:"queryJobId"`
-}
-
-type QueryJobResultColumn struct {
-	Name         string `json:"name"`
-	Type         string `json:"type"`
-	OriginalName string `json:"originalName"`
-	Link         string `json:"link"`
+	QueryStats struct {
+		CPUTimeMillis     int `json:"cpuTimeMillis"`
+		ProcessedRows     int `json:"processedRows"`
+		ProcessedBytes    int `json:"processedBytes"`
+		ElapsedTimeMillis int `json:"elapsedTimeMillis"`
+	} `json:"queryStats"`
+	Status      string           `json:"status"`
+	ID          string           `json:"id"`
+	Name        string           `json:"-"`
+	RowDataHash string           `json:"rowDataHash"`
+	Error       interface{}      `json:"error"`
+	EndTime     string           `json:"endTime"`
+	StartTime   string           `json:"startTime"`
+	RowCount    int              `json:"rowCount"`
+	ResultStore string           `json:"resultStore"`
+	RowData     CustomJSONString `json:"rowData"`
+	CreatedAt   string           `json:"createdAt"`
+	RowNumber   int              `json:"rowNumber"`
+	QueryJobID  string           `json:"queryJobId"`
+	Columns     []QueryJobColumn `json:"columns"`
+	Offset      int              `json:"offset"`
+	Limit       int              `json:"limit"`
+	Items       []QueryJobResult `json:"items"`
+	Links       []LinkItem       `json:"links"`
 }
 
 type QueryJobResultsStats struct {
@@ -83,22 +94,6 @@ type QueryJobResultsStats struct {
 	ProcessedRows     int `json:"processedRows"`
 	ProcessedBytes    int `json:"processedBytes"`
 	ElapsedTimeMillis int `json:"elapsedTimeMillis"`
-}
-
-type QueryJobResults struct {
-	Links       []LinkItem             `json:"links"`
-	Items       []QueryJobResult       `json:"items"`
-	QueryStats  QueryJobResultsStats   `json:"queryStats"`
-	Status      string                 `json:"status"`
-	ID          string                 `json:"id"`
-	Error       QueryError             `json:"error"`
-	EndTime     string                 `json:"endTime"`
-	StartTime   string                 `json:"startTime"`
-	RowCount    int                    `json:"rowCount"`
-	ResultStore string                 `json:"resultStore"`
-	Columns     []QueryJobResultColumn `json:"columns"`
-	Offset      int                    `json:"offset,omitempty"`
-	Limit       int                    `json:"limit,omitempty"`
 }
 
 type LookupTables struct {
@@ -1267,5 +1262,5 @@ type iAPIType interface {
 }
 
 type iAPITypes interface {
-	AlertRules | Destinations | EventExcludeProfiles | EventRules | Users | Roles | ObjectGroups | TagConfigurations | TagRules | Tags | FilePathGroups | YaraGroupRules | RegistryPaths | Querypacks | AuditConfigurations | ComplianceProfiles | AlertRuleCategories | AssetGroupRules | AtcQueries | Carves | CustomProfiles | FlagProfiles | BlockRules | WindowsDefenderPreferences | Exceptions | AssetTags | Assets | LookupTables | QueryJobResults | QueryJobs
+	AlertRules | Destinations | EventExcludeProfiles | EventRules | Users | Roles | ObjectGroups | TagConfigurations | TagRules | Tags | FilePathGroups | YaraGroupRules | RegistryPaths | Querypacks | AuditConfigurations | ComplianceProfiles | AlertRuleCategories | AssetGroupRules | AtcQueries | Carves | CustomProfiles | FlagProfiles | BlockRules | WindowsDefenderPreferences | Exceptions | AssetTags | Assets | LookupTables | QueryJobs | QueryJobResult
 }

--- a/uptycs/query_job.go
+++ b/uptycs/query_job.go
@@ -1,0 +1,47 @@
+package uptycs
+
+import "errors"
+
+func (T QueryJob) GetID() string {
+	return T.ID
+}
+
+func (T QueryJob) GetName() string {
+	return T.Name
+}
+
+func (T QueryJob) KeysToDelete() []string {
+	return []string{
+		"enabled",
+	}
+}
+
+func (c *Client) CreateQueryJob(queryJob QueryJob) (QueryJob, error) {
+	return doCreate(c, queryJob, "queryJobs", []string{})
+}
+
+func (c *Client) UpdateQueryJob(queryJob QueryJob) (QueryJob, error) {
+	return QueryJob{}, errors.New("UPDATE is not supported for query jobs")
+}
+
+func (c *Client) GetQueryJobs() (QueryJobs, error) {
+	return doGetMany(c, QueryJobs{}, "queryTables")
+}
+
+func (c *Client) GetQueryJob(queryJob QueryJob) (QueryJob, error) {
+	if len(queryJob.ID) == 0 {
+		all, _ := c.GetQueryJobs()
+		for _, _item := range all.Items {
+			if _item.Name == queryJob.Name {
+				return _item, nil
+			}
+		}
+	} else {
+		return doGet(c, queryJob, "queryJobs")
+	}
+	return queryJob, errors.New("queryJob was not found")
+}
+
+func (c *Client) DeleteQueryJob(queryJob QueryJob) (QueryJob, error) {
+	return doDelete(c, queryJob, "queryJobs")
+}

--- a/uptycs/query_job.go
+++ b/uptycs/query_job.go
@@ -13,6 +13,13 @@ func (T QueryJob) GetName() string {
 func (T QueryJob) KeysToDelete() []string {
 	return []string{
 		"enabled",
+		"error",
+		"incompleteResults",
+		"purged",
+		"queryId",
+		"resourceType",
+		"resultStore",
+		"rowCount",
 	}
 }
 

--- a/uptycs/query_job_result.go
+++ b/uptycs/query_job_result.go
@@ -1,0 +1,34 @@
+package uptycs
+
+import (
+	"errors"
+	"fmt"
+)
+
+func (T QueryJobResult) GetID() string {
+	return ""
+}
+
+func (T QueryJobResult) GetName() string {
+	return T.Name
+}
+
+func (T QueryJobResult) KeysToDelete() []string {
+	return []string{}
+}
+
+func (c *Client) CreateQueryJobResults(queryJobResult QueryJobResult) (QueryJobResult, error) {
+	return QueryJobResult{}, errors.New("CREATE is not supported for query job results")
+}
+
+func (c *Client) UpdateQueryJobResults(queryJobResult QueryJobResult) (QueryJobResult, error) {
+	return QueryJobResult{}, errors.New("UPDATE is not supported for query job results")
+}
+
+func (c *Client) GetQueryJobResults(queryJobResult QueryJobResult) (QueryJobResult, error) {
+	return doGetMany(c, queryJobResult, fmt.Sprintf("queryJobs/%s/results", queryJobResult.ID))
+}
+
+func (c *Client) DeleteQueryJobResult(queryJobResult QueryJobResult) (QueryJobResult, error) {
+	return QueryJobResult{}, errors.New("DELETE is not supported for query job results")
+}

--- a/uptycs/query_job_result_test.go
+++ b/uptycs/query_job_result_test.go
@@ -1,0 +1,314 @@
+package uptycs
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetQueryJobResult(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name    string
+		fixture string
+		id      string
+		out     interface{}
+	}
+
+	theTests := []convTest{
+		{
+			name:    "TestQueryJobResult",
+			fixture: "fixtures/query_job_result.json",
+			id:      "7bc5024f-003b-4934-97d6-478bc603a684",
+			out: QueryJobResult{
+				QueryStats: struct {
+					CPUTimeMillis     int `json:"cpuTimeMillis"`
+					ProcessedRows     int `json:"processedRows"`
+					ProcessedBytes    int `json:"processedBytes"`
+					ElapsedTimeMillis int `json:"elapsedTimeMillis"`
+				}{
+					CPUTimeMillis:     106,
+					ProcessedRows:     5963,
+					ProcessedBytes:    0,
+					ElapsedTimeMillis: 386,
+				},
+				Status:      "FINISHED",
+				ID:          "7bc5024f-003b-4934-97d6-478bc603a684",
+				Name:        "",
+				RowDataHash: "",
+				Error:       nil,
+				EndTime:     "2023-06-13T15:27:01.209Z",
+				StartTime:   "2023-06-13T15:27:00.692Z",
+				RowCount:    2,
+				ResultStore: "cache",
+				RowData:     "",
+				RowNumber:   0,
+				QueryJobID:  "",
+				Columns: []QueryJobColumn{
+					{
+						Name:         "instance_id",
+						Type:         "TEXT",
+						OriginalName: "instance_id",
+					},
+					{
+						Name:         "tags",
+						Type:         "TEXT",
+						OriginalName: "tags",
+					},
+					{
+						Name:         "foo",
+						Type:         "NUMBER_INTEGER",
+						OriginalName: "foo",
+					},
+				},
+				Offset: 0,
+				Limit:  50000,
+				Items: []QueryJobResult{
+					{
+						QueryStats: struct {
+							CPUTimeMillis     int `json:"cpuTimeMillis"`
+							ProcessedRows     int `json:"processedRows"`
+							ProcessedBytes    int `json:"processedBytes"`
+							ElapsedTimeMillis int `json:"elapsedTimeMillis"`
+						}{
+							CPUTimeMillis:     0,
+							ProcessedRows:     0,
+							ProcessedBytes:    0,
+							ElapsedTimeMillis: 0,
+						},
+						Status:      "",
+						ID:          "",
+						Name:        "",
+						RowDataHash: "248f094d-c546-34dc-8ca2-06c869c4bbed",
+						Error:       nil,
+						CreatedAt:   "2023-06-13",
+						EndTime:     "",
+						StartTime:   "",
+						RowCount:    0,
+						RowData:     "{\"foo\":1,\"instance_id\":\"i-027e4ca22fe5a1518\",\"tags\":\"{\\\"Foo\\\":\\\"some foo\\\"}\"}",
+						ResultStore: "",
+						RowNumber:   1,
+						QueryJobID:  "7bc5024f-003b-4934-97d6-478bc603a684",
+						Columns:     nil,
+						Offset:      0,
+						Limit:       0,
+						Items:       nil,
+						Links:       nil,
+					},
+					{
+						QueryStats: struct {
+							CPUTimeMillis     int `json:"cpuTimeMillis"`
+							ProcessedRows     int `json:"processedRows"`
+							ProcessedBytes    int `json:"processedBytes"`
+							ElapsedTimeMillis int `json:"elapsedTimeMillis"`
+						}{
+							CPUTimeMillis:     0,
+							ProcessedRows:     0,
+							ProcessedBytes:    0,
+							ElapsedTimeMillis: 0,
+						},
+						Status:      "",
+						ID:          "",
+						Name:        "",
+						RowDataHash: "8917663c-4f37-3d28-b771-acfd00f2e816",
+						Error:       nil,
+						CreatedAt:   "2023-06-13",
+						EndTime:     "",
+						StartTime:   "",
+						RowCount:    0,
+						RowData:     "{\"foo\":2,\"instance_id\":\"i-08c0f696e648e37cd\",\"tags\":\"{\\\"Foo\\\":\\\"some other foo\\\"}\"}",
+						ResultStore: "",
+						RowNumber:   2,
+						QueryJobID:  "7bc5024f-003b-4934-97d6-478bc603a684",
+						Columns:     nil,
+						Offset:      0,
+						Limit:       0,
+						Items:       nil,
+						Links:       nil,
+					},
+				},
+				Links: []LinkItem{
+					{
+						Rel:   "self",
+						Title: "Query job results information",
+						Href:  "/api/customers/11111111-1111-1111-1111-111111111111/queryJobs/7bc5024f-003b-4934-97d6-478bc603a684/results",
+					},
+					{
+						Rel:   "parent",
+						Title: "Query job information",
+						Href:  "/api/customers/11111111-1111-1111-1111-111111111111/queryJobs/7bc5024f-003b-4934-97d6-478bc603a684",
+					},
+				},
+			},
+		},
+	}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("GET", fmt.Sprintf("https://uptycs.foo/public/api/customers/d/queryJobs/%v/results", theT.id),
+				func(req *http.Request) (*http.Response, error) {
+					fixture, err := RespFromFixture(theT.fixture)
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return fixture, err
+				},
+			)
+
+			queryJobResp, err := c.GetQueryJobResults(QueryJobResult{
+				ID: theT.id,
+			})
+
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			if !reflect.DeepEqual(queryJobResp, theT.out) {
+				t.Log("Output does not match expected")
+				t.Logf("Expected: %v", theT.out)
+				t.Logf("Actual:   %v", queryJobResp)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestDeleteQueryJobResult(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name string
+		in   QueryJobResult
+	}
+
+	theTests := []convTest{}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://uptycs.foo/public/api/customers/d/queryJobs/%v", theT.in.ID),
+				func(req *http.Request) (*http.Response, error) {
+					resp, err := httpmock.NewJsonResponse(200, "{}")
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return resp, err
+				},
+			)
+
+			_, err := c.DeleteQueryJobResult(theT.in)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			countInfo := httpmock.GetCallCountInfo()
+
+			assert.Equal(t, countInfo[fmt.Sprintf("DELETE https://uptycs.foo/public/api/customers/d/queryJobs/%v", theT.in.ID)], 1)
+			// TODO: assert the body that was intercepted by the mock
+		})
+	}
+}
+
+func TestPutQueryJobResult(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name    string
+		fixture string
+		in      QueryJobResult
+	}
+
+	theTests := []convTest{}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("PUT", fmt.Sprintf("https://uptycs.foo/public/api/customers/d/queryJobs/%v", theT.in.ID),
+				func(req *http.Request) (*http.Response, error) {
+					fixture, err := RespFromFixture(theT.fixture)
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return fixture, err
+				},
+			)
+
+			_, err := c.UpdateQueryJobResults(theT.in)
+
+			expectedErrorMsg := "UPDATE is not supported for lookup tables"
+			assert.EqualErrorf(t, err, expectedErrorMsg, "Error should be: %v, got: %v", expectedErrorMsg, err)
+		})
+	}
+}
+
+func TestCreateQueryJobResult(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name    string
+		fixture string
+		in      QueryJobResult
+	}
+
+	theTests := []convTest{}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("POST", "https://uptycs.foo/public/api/customers/d/queryJobs",
+				func(req *http.Request) (*http.Response, error) {
+					fixture, err := RespFromFixture(theT.fixture)
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return fixture, err
+				},
+			)
+
+			_, err := c.CreateQueryJobResults(theT.in)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			countInfo := httpmock.GetCallCountInfo()
+
+			assert.Equal(t, countInfo["POST https://uptycs.foo/public/api/customers/d/queryJobs"], 1)
+		})
+	}
+}

--- a/uptycs/query_job_test.go
+++ b/uptycs/query_job_test.go
@@ -53,11 +53,11 @@ func TestGetQueryJob(t *testing.T) {
 					},
 				},
 				ParameterValues: struct {
-					From string `json:"from"`
-					To   string `json:"to"`
+					From string `json:"from,omitempty"`
+					To   string `json:"to,omitempty"`
 				}{
-					To:   "2023-05-22T19:27:08.322Z",
 					From: "2023-05-22T17:22:36.323Z",
+					To:   "2023-05-22T19:27:08.322Z",
 				},
 				QueryID:           "4934a4b8-0625-452f-b5ec-0d6be1da2d85",
 				Status:            "QUEUED",

--- a/uptycs/query_job_test.go
+++ b/uptycs/query_job_test.go
@@ -1,0 +1,253 @@
+package uptycs
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetQueryJob(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name    string
+		fixture string
+		id      string
+		out     interface{}
+	}
+
+	theTests := []convTest{
+		{
+			name:    "TestQueryJob",
+			fixture: "fixtures/query_job.json",
+			id:      "b6885999-3bb0-4d8e-84b3-46883f4d7506",
+			out: QueryJob{
+				ID:    "b6885999-3bb0-4d8e-84b3-46883f4d7506",
+				Name:  "b86c2befb58987cb5d4f14210784c9df",
+				Query: "test",
+				Type:  "global",
+				Parameters: []QueryJobParameter{
+					{
+						Key:          "from",
+						DataType:     "DATE",
+						Multiple:     false,
+						Optional:     false,
+						DefaultValue: "2023-05-22T17:22:36.323Z",
+					},
+					{
+						Key:          "to",
+						DataType:     "DATE",
+						Multiple:     false,
+						Optional:     false,
+						DefaultValue: "2023-05-22T19:27:08.322Z",
+					},
+				},
+				ParameterValues: struct {
+					From string `json:"from"`
+					To   string `json:"to"`
+				}{
+					To:   "2023-05-22T19:27:08.322Z",
+					From: "2023-05-22T17:22:36.323Z",
+				},
+				QueryID:           "4934a4b8-0625-452f-b5ec-0d6be1da2d85",
+				Status:            "QUEUED",
+				RowCount:          0,
+				Columns:           nil,
+				StartTime:         "",
+				EndTime:           "",
+				Error:             QueryError{},
+				Purged:            false,
+				IncompleteResults: false,
+				AlertID:           "",
+				CreatedBy:         "f48f4c40-9c4a-47bb-9e3f-797d4deca92a",
+				UpdatedBy:         "",
+				CreatedAt:         "2023-05-22T19:27:08.334Z",
+				UpdatedAt:         "2023-05-22T19:27:08.334Z",
+				Source:            "SCHEDULED",
+				ResultStore:       "",
+				AgentType:         "asset",
+				ResourceType:      "asset",
+				Links: []LinkItem{
+					{
+						Rel:   "self",
+						Title: "Query job information",
+						Href:  "/api/customers/11111111-1111-1111-1111-111111111111/queryJobs/b6885999-3bb0-4d8e-84b3-46883f4d7506",
+					},
+					{
+						Rel:   "parent",
+						Title: "Query jobs information",
+						Href:  "/api/customers/11111111-1111-1111-1111-111111111111/queryJobs",
+					},
+				},
+			},
+		},
+	}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("GET", fmt.Sprintf("https://uptycs.foo/public/api/customers/d/queryJobs/%v", theT.id),
+				func(req *http.Request) (*http.Response, error) {
+					fixture, err := RespFromFixture(theT.fixture)
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return fixture, err
+				},
+			)
+
+			queryJobResp, err := c.GetQueryJob(QueryJob{
+				ID: theT.id,
+			})
+
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			if !reflect.DeepEqual(queryJobResp, theT.out) {
+				t.Log("Output does not match expected")
+				t.Logf("Expected: %v", theT.out)
+				t.Logf("Actual:   %v", queryJobResp)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestDeleteQueryJob(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name string
+		in   QueryJob
+	}
+
+	theTests := []convTest{}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://uptycs.foo/public/api/customers/d/queryJobs/%v", theT.in.ID),
+				func(req *http.Request) (*http.Response, error) {
+					resp, err := httpmock.NewJsonResponse(200, "{}")
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return resp, err
+				},
+			)
+
+			_, err := c.DeleteQueryJob(theT.in)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			countInfo := httpmock.GetCallCountInfo()
+
+			assert.Equal(t, countInfo[fmt.Sprintf("DELETE https://uptycs.foo/public/api/customers/d/queryJobs/%v", theT.in.ID)], 1)
+			// TODO: assert the body that was intercepted by the mock
+		})
+	}
+}
+
+func TestPutQueryJob(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name    string
+		fixture string
+		in      QueryJob
+	}
+
+	theTests := []convTest{}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("PUT", fmt.Sprintf("https://uptycs.foo/public/api/customers/d/queryJobs/%v", theT.in.ID),
+				func(req *http.Request) (*http.Response, error) {
+					fixture, err := RespFromFixture(theT.fixture)
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return fixture, err
+				},
+			)
+
+			_, err := c.UpdateQueryJob(theT.in)
+
+			expectedErrorMsg := "UPDATE is not supported for lookup tables"
+			assert.EqualErrorf(t, err, expectedErrorMsg, "Error should be: %v, got: %v", expectedErrorMsg, err)
+		})
+	}
+}
+
+func TestCreateQueryJob(t *testing.T) {
+
+	c, _ := NewClient(Config{
+		Host:       "https://uptycs.foo",
+		APIKey:     "b",
+		APISecret:  "c",
+		CustomerID: "d",
+	})
+
+	type convTest struct {
+		name    string
+		fixture string
+		in      QueryJob
+	}
+
+	theTests := []convTest{}
+
+	for _, theT := range theTests {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		t.Run(theT.name, func(t *testing.T) {
+			httpmock.RegisterResponder("POST", "https://uptycs.foo/public/api/customers/d/queryJobs",
+				func(req *http.Request) (*http.Response, error) {
+					fixture, err := RespFromFixture(theT.fixture)
+					if err != nil {
+						t.Errorf(err.Error())
+					}
+					return fixture, err
+				},
+			)
+
+			_, err := c.CreateQueryJob(theT.in)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			countInfo := httpmock.GetCallCountInfo()
+
+			assert.Equal(t, countInfo["POST https://uptycs.foo/public/api/customers/d/queryJobs"], 1)
+		})
+	}
+}

--- a/uptycs/utils.go
+++ b/uptycs/utils.go
@@ -94,17 +94,31 @@ func doGet[T iAPIType](c *Client, apiObject T, endpointStr string) (T, error) {
 
 	foundItems := make([]T, 1)
 
-	if len(apiObject.GetID()) == 0 {
-		// Attempt to get by name using doGetMany() and GetName() on each
-		panic("TODO: support get by name if len(GetID()) is 0")
-	} else {
-		err = json.Unmarshal(body, &foundItems[0])
-		if err != nil {
-			return apiObject, err
-		}
+	err = json.Unmarshal(body, &foundItems[0])
+	if err != nil {
+		return apiObject, err
 	}
 
 	return foundItems[0], nil
+}
+
+func doCreateRaw(c *Client, body string, endpointStr string) error {
+	req, err := http.NewRequest(
+		"POST",
+		fmt.Sprintf("%s/%s", c.HostURL, endpointStr),
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	if err != nil {
+		return err
+	}
+
+	_, err = c.doRequest(req)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func doCreate[T iAPIType](c *Client, apiObject T, endpointStr string, additionalKeysToDelete []string) (T, error) {


### PR DESCRIPTION
This adds support for managing lookup tables and data therein:

```
	// Create a lookupTable
	newLookupTable, err := c.CreateLookupTable(uptycs.LookupTable{
		Name:        "test",
		Description: "a test",
		IDField:     "id",
	})
	if err != nil {
		panic(err)
	}
	log.Println(fmt.Sprintf("Created lookupTable '%s' with id '%s'", newLookupTable.Name, newLookupTable.ID))

	// Add some data rows
	_, err = c.CreateLookupTableDataRow(
		newLookupTable,
		uptycs.LookupTableDataRow{
			Data: "[{\"id\": \"foo\", \"exception\":\"bar\"}]",
		},
	)
	_, err = c.CreateLookupTableDataRow(
		newLookupTable,
		uptycs.LookupTableDataRow{
			Data: "[{\"id\": \"asdf\", \"exception\":\"wut\"}]",
		},
	)
	//Update Some data
	_, err = c.UpdateLookupTableDataRow(
		newLookupTable,
		uptycs.LookupTableDataRow{
			IDFieldValue: "foo",
			Data:         "[{\"id\": \"foo\", \"exception\":\"new bar\"}]",
		},
	)

	//Delete Some data
	_, err = c.DeleteLookupTableDataRow(
		newLookupTable,
		uptycs.LookupTableDataRow{
			IDFieldValue: "foo",
		},
	)
	_test, _ := c.GetLookupTable(uptycs.LookupTable{
		ID: newLookupTable.ID,
	})
	log.Println(fmt.Sprintf("%+v", _test.DataRows[0].Data))
```

```
✗ go run _examples/lookup_table.go

2023/06/05 12:32:38 Got LookupTable with ID  7f042e5a-e4e8-47e7-8077-a0581411d4fd                                                                                            
2023/06/05 12:32:38 {"id":210246326331,"name":"prod","owner":"Saad Rehmani"}                                                                                                 
2023/06/05 12:32:38 Created lookupTable 'test' with id '1d0360f6-bebe-479c-8e1e-635e18bb28a4'                                                                                
2023/06/05 12:32:40 {"id":"asdf","exception":"wut"}                                                                                                                          
2023/06/05 12:32:40 Deleted lookupTable 'test' with id '1d0360f6-bebe-479c-8e1e-635e18bb28a4'  
```

This also adds support for creating queries and retrieving the results

```
	c, _ := uptycs.NewClient(uptycs.Config{
		Host:       os.Getenv("UPTYCS_HOST"),
		APIKey:     os.Getenv("UPTYCS_API_KEY"),
		APISecret:  os.Getenv("UPTYCS_API_SECRET"),
		CustomerID: os.Getenv("UPTYCS_CUSTOMER_ID"),
	})

	newQueryJob, err := c.CreateQueryJob(uptycs.QueryJob{
		Name:  "test",
		Query: heredoc.Doc(`SELECT instance_id,tags from aws_ec2_instance_current limit 1;`),
		Type:  "global",
	})

	if err != nil {
		log.Fatal(err)
	}
	log.Println(fmt.Sprintf("Created Query Job  with id '%s'", newQueryJob.ID))
	time.Sleep(10 * time.Second)

	_foo, err := c.GetQueryJobResults(uptycs.QueryJobResult{
		ID: newQueryJob.ID,
	})
	if err != nil {
		log.Fatal(err)
	}
	log.Println(fmt.Sprintf("%+v", _foo.Items[0].RowData))

}
```